### PR TITLE
Feature/add user geolocation to header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,7 @@ import useWindowDimensions from '../hooks/useWindowDimensions';
 
 import Input from './Input';
 import Menu from './Menu';
+import useGeolocation from '../hooks/useGeolocation';
 
 interface IHeaderProps {
   title?: string | string[] | undefined;
@@ -13,6 +14,7 @@ interface IHeaderProps {
 
 export default function Header({ title, isFixed }: IHeaderProps) {
   const { width } = useWindowDimensions();
+  const { address } = useGeolocation();
 
   return (
     <Container hasTitle={!!title} isFixed={isFixed}>
@@ -52,7 +54,7 @@ export default function Header({ title, isFixed }: IHeaderProps) {
               </>
             ) : (
               <>
-                <h3>Av. Ceará, 1039</h3>
+                <h3>{address}</h3>
                 <FiChevronDown color="#ea1d2c" size={18} />
               </>
             )}

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-icons/fi';
 import { Container } from '../styles/components/Menu';
 import FloatingBox from './FloatingBox';
+import useGeolocation from '../hooks/useGeolocation';
 
 export default function Categories() {
   const [openOption, setOpenOption] = useState(false);
@@ -16,13 +17,15 @@ export default function Categories() {
     setOpenOption(!openOption);
   }, [openOption]);
 
+  const { address } = useGeolocation();
+
   return (
     <Container>
       <section>
         <span>Entregar em</span>
         <div>
           <FiHome size={18} />
-          <h4>Av. Ceará, 1039</h4>
+          <h4>{address}</h4>
           <FiChevronDown size={16} />
         </div>
       </section>

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import api from '../services/api';
+
+interface IGeolocation {
+  address: {
+    road: string;
+    city: string;
+  };
+}
+
+export default function useGeolocation() {
+  const [location, setLocation] = useState<[number, number]>([0, 0]);
+  const [address, setAddress] = useState('');
+
+  useEffect(() => {
+    navigator.geolocation.getCurrentPosition(position => {
+      const { latitude, longitude } = position.coords;
+      setLocation([latitude, longitude]);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (location[0]) {
+      api
+        .get<IGeolocation>(
+          `https://nominatim.openstreetmap.org/reverse?format=json&lat=${location[0]}&lon=${location[1]}&zoom=18&addressdetails=1`,
+        )
+        .then(response => {
+          setAddress(`${response.data.address.road}`);
+        });
+    }
+  }, [location]);
+
+  return { address };
+}

--- a/src/styles/components/Menu.ts
+++ b/src/styles/components/Menu.ts
@@ -25,6 +25,7 @@ export const Container = styled.div`
         font-weight: 300;
         /* color: ${props => props.theme.colors.fontPrimary}; */
         color: #3e3e3e;
+        width: 170px;
       }
 
       svg {


### PR DESCRIPTION
- Create the `useGeolocation` hook to be able to get the user location in any page/component using the Geolocation API.
- Change the fixed address to the user address using Reverse Geocoding [Nominatim API](https://nominatim.openstreetmap.org/ui/search.html)
- Change div width style to fit bigger addresses.

Close #2 